### PR TITLE
Added a gliffy link to architecture diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # DevOps Apprenticeship: Project Exercise
 
+## Architecture Diagram
+
+[Architecture Diagrams](https://go.gliffy.com/go/share/s284x0ldwswfqfkx7o3o)
+
 ## System Requirements
 
 The project uses poetry for Python to create an isolated environment and manage package dependencies. To prepare your system, ensure you have an official distribution of Python version 3.7+ and install poetry using one of the following commands (as instructed by the [poetry documentation](https://python-poetry.org/docs/#system-requirements)):

--- a/todo_app/data/todo.py
+++ b/todo_app/data/todo.py
@@ -188,7 +188,7 @@ class TodoService:
 
     def delete_item(self, id):
         """
-        Delets an existing item in the Trello board.
+        Deletes an existing item in the Trello board.
 
         Args:
             item: The item to delete.


### PR DESCRIPTION
Please make sure you are raising this PR against your own repository and not the original. If it says https://github.com/CorndelWithSoftwire in the search bar right now, you are in the wrong place!

Please also don't forget to submit the PR's url to Aptem afterwards (by clicking on the corresponding exercise component, pasting the url in the textbox that appears and then pressing the finish button).

Please click on the link in Readme file to navigate to architecture diagrams